### PR TITLE
relax assertion for X-Frame-Options to allow DENY (uppercase)

### DIFF
--- a/tests_suite.yml
+++ b/tests_suite.yml
@@ -43,7 +43,7 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200    
     - result.headers.x-frame-options ShouldNotBeNil
-    - result.headers.x-frame-options ShouldEqual "deny"
+    - result.headers.x-frame-options ShouldBeIn "deny" "DENY"
 - name: X-Content-Type-Options
   steps:
   - type: http


### PR DESCRIPTION
As mentioned in https://github.com/oshp/oshp-validator/issues/1, I think the assertion for `X-Frame-Options` should allow for both upper- and lower-cased "deny".

Tested this against the following scenarios:
* Site running with `X-Frame-Options: DENY` -- success
* Site running with `X-Frame-Options: deny` -- success
* Site running without `X-Frame-Options` -- fail