### PR TITLE
Strict-Transport-Security - Add preload support.

### DIFF
--- a/tests_suite.yml
+++ b/tests_suite.yml
@@ -14,7 +14,9 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.headers.Strict-Transport-Security ShouldNotBeNil
-          - result.headers.Strict-Transport-Security ShouldBeIn "max-age=31536000; includeSubDomains" "max-age=31536000; includeSubDomains; preload"
+          - or:
+            - result.headers.Strict-Transport-Security ShouldEqual "max-age=31536000; includeSubDomains"
+            - result.headers.Strict-Transport-Security ShouldEqual "max-age=31536000; includeSubDomains; preload"
   - name: X-Frame-Options
     steps:
       - type: http

--- a/tests_suite.yml
+++ b/tests_suite.yml
@@ -14,7 +14,7 @@ testcases:
         assertions:
           - result.statuscode ShouldEqual 200
           - result.headers.Strict-Transport-Security ShouldNotBeNil
-          - result.headers.Strict-Transport-Security ShouldEqual "max-age=31536000; includeSubDomains"
+          - result.headers.Strict-Transport-Security ShouldBeIn "max-age=31536000; includeSubDomains" "max-age=31536000; includeSubDomains; preload"
   - name: X-Frame-Options
     steps:
       - type: http


### PR DESCRIPTION
At the moment, tests that have preload in the header fail. Even though from my understanding this is more secure.

Therefore this pull requests proposes to use the [logical operators](https://github.com/ovh/venom?tab=readme-ov-file#using-logical-operators) feature, to include an optional response. 